### PR TITLE
Fix Negative Fee Bug

### DIFF
--- a/src/main.rb
+++ b/src/main.rb
@@ -280,11 +280,11 @@ cli = Cliqr.interface do
                 reward_block = true
               else
                 previousOutputTxid = vin['txid']
-                output = Output[:transaction_id => Transaction[:txid => previousOutputTxid].id]
+                output = Transaction[:txid => previousOutputTxid]
                 db_input.outputTxid = previousOutputTxid
-                db_input.outputTransactionId = output.transaction_id
-                total_input += output.value
-                db_input.value = output.value
+                db_input.outputTransactionId = output.id
+                total_input += output.totalOutput
+                db_input.value = output.totalOutput
                 db_input.save
               end
             end


### PR DESCRIPTION
Bug was caused by thinking that only one output entry would exist per transaction. Several transactions have 2 outputs redeemed in the same block. The old code would only pull 1 of the outputs to add into the total_input, resulting in a lower than expected number.

The transaction entry contains both the db id and the output value needed, ensuring the correct number is passed as the total for each input.
