### PR TITLE
Data migrations for block data

### DIFF
--- a/src/main.rb
+++ b/src/main.rb
@@ -249,7 +249,7 @@ cli = Cliqr.interface do
 
           sleep(3)
 
-          (highest_block..200).each do |block_num| hash = silkroad.rpc 'getblockhash', block_num
+          (highest_block..block_count).each do |block_num| hash = silkroad.rpc 'getblockhash', block_num
           block = silkroad.rpc 'getblock', hash
 
           db_raw_block = RawBlock.new

--- a/src/migrations/002_add_new_block_data.rb
+++ b/src/migrations/002_add_new_block_data.rb
@@ -1,0 +1,35 @@
+require 'json'
+
+require './src/models/block'
+require './src/models/raw_block'
+
+Sequel.migration do
+  up do
+    alter_table(:blocks) do
+      add_column :blockSize, Fixnum
+      add_column :merkleRoot, String
+      add_column :difficulty, Float
+    end
+
+    Block.set_dataset(:blocks)
+
+    raw_blocks = RawBlock.all
+    raw_blocks.each do |raw_block|
+      block_info = raw_block.raw
+      block_json = JSON.parse(block_info)
+      Block[:height => raw_block.height].update(
+          :blockSize => block_json.fetch("size").to_i,
+          :merkleRoot => block_json.fetch("merkleroot"),
+          :difficulty => block_json.fetch("difficulty").to_f
+      )
+    end
+  end
+
+  down do
+    alter_table(:blocks) do
+      drop_column :blockSize
+      drop_column :merkleRoot
+      drop_column :difficulty
+    end
+  end
+end

--- a/src/migrations/002_add_new_block_data.rb
+++ b/src/migrations/002_add_new_block_data.rb
@@ -13,6 +13,12 @@ Sequel.migration do
 
     Block.set_dataset(:blocks)
 
+    Block[:height => 0].update(
+        :blockSize => 217,
+        :merkleRoot => '1552f748afb7ff4e04776652c5a17d4073e60b7004e9bca639a99edb82aeb1a0',
+        :difficulty => 0.00024414
+    )
+
     raw_blocks = RawBlock.all
     raw_blocks.each do |raw_block|
       block_info = raw_block.raw


### PR DESCRIPTION
Migrations for the new block data in #7 were missed. This PR add the migrations for those columns. It also implements database version checking to ensure migrations have to be run before the application will start.
#12 will need to be merged before this can be merged.

Closes #13 
